### PR TITLE
Enhance the application module's handling

### DIFF
--- a/django_atlassian/templates/django_atlassian/base.html
+++ b/django_atlassian/templates/django_atlassian/base.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="ap-local-base-url" content="{{localBaseUrl}}">
+  <title>{{title}}</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+  <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+
+  <!--  AUI Core -->
+  <script src="https://aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui.min.js"></script>
+  <link rel="stylesheet" href="https://aui-cdn.atlassian.com/aui-adg/6.0.9/css/aui.min.css" media="all">
+
+  <!-- AUI Experimental components -->
+  <link rel="stylesheet" href="https://aui-cdn.atlassian.com/aui-adg/6.0.9/css/aui-experimental.min.css" media="all">
+  <script src="https://aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui-experimental.min.js"></script>
+  <!-- AUI Datepicker and Soy templates -->
+  <script src="https://aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui-datepicker.min.js"></script>
+  <script src="https://aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui-soy.min.js"></script>
+
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" media="all">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+
+  <script src="https://fluendo.atlassian.net/atlassian-connect/all.js"></script>
+  <script src="https://connect-cdn.atl-paas.net/all.js"></script>
+
+</head>
+
+<body "ac-content" style="background: white;">
+  <section id="content" role="main">
+    {% block content %}
+    {% endblock %}
+  </section>
+
+  <script>
+      AP.resize('100%','100%');
+      AP.sizeToParent();
+  </script>
+
+</body>
+</html>

--- a/django_atlassian/templates/django_atlassian/confluence/atlassian-connect.json
+++ b/django_atlassian/templates/django_atlassian/confluence/atlassian-connect.json
@@ -1,0 +1,20 @@
+{
+    "name": "{{ name }}",
+    "description": "{{ description }}",
+    "key": "{{ key }}",
+    "baseUrl": "{{ base_url }}",
+    "vendor": {
+        "name": "{{ vendor_name }}",
+        "url": "{{ vendor_url }}",
+    },
+    "authentication": {
+        "type": "jwt"
+    },
+    "lifecycle": {
+        "installed": "{% url 'django-atlassian-installed' %}"
+    },
+    "scopes": [
+        "read", "write"
+    ],
+    "modules": {{ modules|safe }}
+}

--- a/django_atlassian/templates/django_atlassian/jira/atlassian-connect.json
+++ b/django_atlassian/templates/django_atlassian/jira/atlassian-connect.json
@@ -1,0 +1,21 @@
+{
+    "name": "{{ name }}",
+    "description": "{{ description }}",
+    "key": "{{ key }}",
+    "baseUrl": "{{ base_url }}",
+    "vendor": {
+        "name": "{{ vendor_name }}",
+        "url": "{{ vendor_url }}",
+    },
+    "authentication": {
+        "type": "jwt"
+    },
+    "lifecycle": {
+        "installed": "{% url 'django-atlassian-installed' %}"
+    },
+    "scopes": [
+        "read", "write"
+    ],
+    "apiVersion": 1,
+    "modules": {{ modules|safe }}
+}

--- a/django_atlassian/urls.py
+++ b/django_atlassian/urls.py
@@ -7,5 +7,6 @@ import views
 
 urlpatterns = [
     url(r'^installed/$', views.installed, name='django-atlassian-installed'),
+    url(r'^jira/$', views.JiraDescriptor.as_view(), name='django-atlassian-jira-connect-json'),
+    url(r'^confluence/$', views.ConfluenceDescriptor.as_view(), name='django-atlassian-confluence-connect-json'),
 ]
-

--- a/django_atlassian/views.py
+++ b/django_atlassian/views.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from importlib import import_module
 import json
 import jwt
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.csrf import csrf_exempt
+from django.conf import settings
+from django.apps import apps
+from django.views.generic.base import TemplateView
+from django.core.exceptions import ImproperlyConfigured
 
 from models.connect import SecurityContext
 
@@ -49,3 +54,51 @@ def installed(request):
         sc.save()
 
     return HttpResponse(status=204)
+
+
+class ApplicationDescriptor(TemplateView):
+    content_type = 'application/json'
+
+    def get_application_name(self):
+        if self.application_name is None:
+            raise ImproperlyConfigured(
+                "ApplicationDescriptor requires a definition of 'application_name' "
+                "or an implementation of 'get_application_name()'")
+        return self.application_name
+
+    def get_template_names(self):
+        return ['django_atlassian/{}/atlassian-connect.json'.format(self.get_application_name())]
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(ApplicationDescriptor, self).get_context_data(*args, **kwargs)
+        base_url = self.request.build_absolute_uri('/')
+        context['base_url'] = getattr(settings, 'URL_BASE', base_url)
+        # Get all the contents of the registered apps application_name_modules.py files
+        modules = {}
+        for app in apps.get_app_configs():
+            try:
+                module = import_module('{}.{}_modules'.format(app.module.__name__, self.get_application_name()))
+                for m in module.modules:
+                    for k,v in m.items():
+                        if not k in modules.keys():
+                            modules[k] = []
+                        modules[k] = modules[k] + v
+            except ImportError:
+                continue
+        context['modules'] = json.dumps(modules)
+        # Get the needed settings or abort
+        context['name'] = getattr(settings, 'DJANGO_ATLASSIAN_{}_NAME'.format(self.get_application_name().upper()))
+        context['description'] = getattr(settings, 'DJANGO_ATLASSIAN_{}_DESCRIPTION'.format(self.get_application_name().upper()))
+        context['key'] = getattr(settings, 'DJANGO_ATLASSIAN_{}_KEY'.format(self.get_application_name().upper()))
+        context['vendor_name'] = getattr(settings, 'DJANGO_ATLASSIAN_VENDOR_NAME')
+        context['vendor_url'] = getattr(settings, 'DJANGO_ATLASSIAN_VENDOR_URL')
+
+        return context
+
+
+class JiraDescriptor(ApplicationDescriptor):
+    application_name = 'jira'
+
+
+class ConfluenceDescriptor(ApplicationDescriptor):
+    application_name = 'confluence'


### PR DESCRIPTION
Now, every app can provide it's own jira_modules.py or
confluence_modules.py and the system will generate the
corresponding json description.
Also, some settings variables are now mandatory in order
to provide the json description correctly.