### PR TITLE
Install token configuration

### DIFF
--- a/django_atlassian/models/connect.py
+++ b/django_atlassian/models/connect.py
@@ -35,7 +35,7 @@ class SecurityContext(models.base.Model):
             token = jwt.encode(key=self.shared_secret, algorithm='HS256', payload={
                 'aud': self.client_key,
                 'sub': account,
-                'iss': self.client_key,
+                'iss': self.key,
                 'qsh': hash_url(method, uri),
                 'iat': now,
                 'exp': now + 30,


### PR DESCRIPTION
Hi @turran 

Great work with this app. I noticed the `iss` key of the payload when creating the connect token is using the `client_key` rather than the addon key and according to the [docs](https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/#creating-a-jwt-token), it should be the addon key. I don't know if that was a problem before but under the current config that token wasn't being authenticated when used.